### PR TITLE
Corrected mistranslation

### DIFF
--- a/src/Files/MultilingualResources/Files.ar.xlf
+++ b/src/Files/MultilingualResources/Files.ar.xlf
@@ -484,7 +484,7 @@
         </trans-unit>
         <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
-          <target state="translated">اسم الملف يجب ان يحتوي على: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+          <target state="translated">اسم الملف لا يجب ان يحتوي على: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
         <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>


### PR DESCRIPTION
Corrected mistranslation of "The item name must not contain the following characters" on line 487 as the arabic translation said "The item name must contain"

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- Fixed... 
- Corrected mistranslation of "The item name must not contain the following characters" on line 487 as the arabic translation said "The item name must contain"


**Validation**
How did you test these changes?
- [True] Built and ran the app
- [True] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
